### PR TITLE
Debug

### DIFF
--- a/labs/lab2/_coordinator.py
+++ b/labs/lab2/_coordinator.py
@@ -23,6 +23,7 @@ class Coordinator(Process):
     TEST_MAPPER = 'test_mapper'
     TEST_REDUCER = 'test_reducer'
     TEST_BOTH = 'test_both'
+    TEST_ALL = 'test_all'
 
     def __str__(self) -> str:
       return self.value

--- a/labs/lab2/reducer.py
+++ b/labs/lab2/reducer.py
@@ -19,6 +19,17 @@ from mylog import Logger
 
 logging = Logger().get_logger()
 
+
+def recvall(sock: socket.socket, length: int) -> bytes:
+    data = b''
+    while len(data) < length:
+        packet = sock.recv(length - len(data))
+        if not packet:
+            raise Exception("Connection closed before receiving the full message")
+        data += packet
+    return data
+
+
 @dataclass
 class ReducerState:
   pid: int
@@ -189,7 +200,7 @@ class Reducer(Process):
   def handle_mappers(self, client_socket: socket.socket, cmd_q: queue.Queue[Cmd], barrier: threading.Barrier):
     try:
       while True:
-        data = client_socket.recv(1024)
+        data = recvall(client_socket, 1024)
         if not data:
           break
         message = Message.deserialize(data)

--- a/labs/lab2/reducer.py
+++ b/labs/lab2/reducer.py
@@ -25,7 +25,7 @@ def recvall(sock: socket.socket, length: int) -> bytes:
     while len(data) < length:
         packet = sock.recv(length - len(data))
         if not packet:
-            raise Exception("Connection closed before receiving the full message")
+            raise Exception("Connection closed")
         data += packet
     return data
 


### PR DESCRIPTION
Fixed a bug in `reducer.py`. We were using `recv(1024)` to receive messages on TCP connection from mapper. However `recv()` doesn't guarantee that all 1024 bytes will be received at once. To fix this we call `recv()` function until we get all 1024 bytes in a while loop (see `recvall()` in `reducer.py`). 